### PR TITLE
fix: fetching images on the server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ node_modules
 /build
 .env
 .dev.vars
+
+.DS_Store


### PR DESCRIPTION
Cloudflare has this quirk where you can't make a raw request to itself (as a security measure or something). Instead, we use partykit's asset fetcher to fetch images.